### PR TITLE
7 feature request argument parsing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -66,7 +66,7 @@ Directory Settings:
 * Run the bash script [automate_tests.sh](https://github.com/siminegroup/E2EDNA2/blob/main/automate_tests.sh) to test run all 8 modes automatically. Check out [Test runs](https://github.com/siminegroup/E2EDNA2#5-test-runs-inputs-and-outcomes) section for details. 
 * All 8 modes take about 15 minutes to run on a macbook pro laptop and the outputs are saved in the work directory. We chose very simple systems for the the test-run and where ever docking is performed the docking configuration may or may not be found due to the limitations of the chosen system. Please note that a failure to find a docked configuration is not a failure of E2EDNA.
 
-Running on your own data
+### Running on your own data
 * Alternatively, a single run can be carried out by specifying the following parameters: run_num, mode, aptamer sequence, and ligand's structural file. For example,
 ```
 # Modeling a free aptamer with no ligand
@@ -84,14 +84,14 @@ Parameters passed as command line inputs:
   * `-a/--aptamer`: DNA aptamer sequence (5'->3'). Can be a string or the name of a readable text file containing the sequence.
   * `-l/--ligand`: PDB filename of target ligand; If no ligand, `--ligand False` and the following two inputs (`--ligand_type` and `--ligand_seq`) can be left off.
   * `-t/--ligand_type`: 'peptide', 'DNA', 'RNA', or 'other', assuming 'other' ligand can be described by force field used in MD simulation (default: Amber14).
-  * `-s/--ligand_seq`: target ligand's sequence (5'->3') if target ligand is a peptide or DNA or RNA. Can be a string or the name of a readable text file containing the sequence. If `--ligand_type='other'`, do not use this flag.
+  * `-s/--ligand_seq`: target ligand's sequence (5'->3') if target ligand is a peptide or DNA or RNA. Can be a string or the name of a readable text file containing the sequence. If `--ligand_type other`, do not use this flag.
 * System Configuration
   * `-d/--device`: running device; either 'local' or 'cluster'
   * `-p/--platform`: processing platform; either 'CPU' or 'CUDA'
 * Directory Settings
   * `-w/--workdir`: ouput directory to write results for each run
   * `-md/--mmb_dir`: MMB library directory. Wildcards can be used to describe location, for instance the default is "Installer-*/lib" which will match both "Installer-3.0-Ubuntu18.04/lib" and "Installer.3_0.OSX/lib". Both absolute and relative paths are accepted.
-  * `-mb/--mmb`: path to MMB executable. Wild cards can be used to describe location.
+  * `-mb/--mmb`: path to MMB executable. Wild cards can be used to describe location. Both absolute and relative paths are accepted.
 
 * A handful of parameters can be adjusted in [main.py](https://github.com/siminegroup/E2EDNA2/blob/main/main.py) to allow for flexible control of the simulation conditions, including solvent ionic strength, temperature, pH, implicit solvent, simulation force field, etc.
 

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # Documentation
 ## E2EDNA 2.0 - OpenMM Implementation of E2EDNA !
 
-### An automated pipeline for simulating DNA aptamers complexed with target ligands (peptide, DNA, RNA or small molecules)../m  
+### An automated pipeline for simulating DNA aptamers complexed with target ligands (peptide, DNA, RNA or small molecules).
 
 **Michael Kilgour, Tao Liu, Ilya S. Dementyev, Lena Simine**
 

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # Documentation
 ## E2EDNA 2.0 - OpenMM Implementation of E2EDNA !
 
-### An automated pipeline for simulating DNA aptamers complexed with target ligands (peptide, DNA, RNA or small molecules).
+### An automated pipeline for simulating DNA aptamers complexed with target ligands (peptide, DNA, RNA or small molecules)../m  
 
 **Michael Kilgour, Tao Liu, Ilya S. Dementyev, Lena Simine**
 
@@ -18,36 +18,84 @@ This installation path has been tested on macOS and it relies on conda and pip p
    * To fix this issue, please, first remove the installed environment by ``conda remove --name e2edna --all`` in command line, then either replace the conda activation command in the script with `source activate /path-to-envs/e2edna`, e.g., `source activate ~/miniconda3/envs/e2edna` and run the script again
    * OR run the commands one by one interactively in your terminal. 
 5. Register and download MMB from https://simtk.org/projects/rnatoolbox. Place the "Installer.*version.OS*" folder, such as "Installer.3_0.OSX" into the E2EDNA2 directory. N.B.: Do not specify `DYLD_LIBRARY_PATH` for macOS against the recommendations of the MMB installation guide. This is to avoid interference with the OpenMM module.
-6. Update 3 paths in [main.py](https://github.com/siminegroup/E2EDNA2/blob/main/main.py):
+
+## 2. Usage
+
+The usage and help statements can be accessed with the `-h/--help` flags:
+
 ```
-params['workdir'] = '/path-to-E2EDNA2-main/localruns'                                # directory manually created to store all future jobs
-params['mmb dir'] = '/path-to-E2EDNA2-main/Installer.version.OS/lib'                 # path to MMB dylib files
-params['mmb']     = '/path-to-E2EDNA2-main/Installer.version.OS/bin/MMB-executable'  # path to MMB executable
+$ ./main.py --help
+usage: main.py [-h] [-f] -r INT -m MODE -a SEQ -l PDB [-t TYPE] [-s SEQ]
+               [-d RUN] [-p DEV] [-w DIR] [-md DIR] [-mb MMB]
+
+E2EDNA: Simulate DNA aptamers complexed with target ligands
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -f, --force           Overwrite existing --run_num (default: False)
+
+Run Parameters:
+  -r INT, --run_num INT
+                        Run number. Output will be written to
+                        {--workdir}/run{--run_num}/ (default: None)
+  -m MODE, --mode MODE  Run mode (default: None)
+  -a SEQ, --aptamer SEQ
+                        DNA Aptamer sequence (5'-3') (default: None)
+  -l PDB, --ligand PDB  Filename of target ligand (default: None)
+  -t TYPE, --ligand_type TYPE
+                        Target ligand molecule type (default: )
+  -s SEQ, --ligand_seq SEQ
+                        Target ligand sequence if peptide, DNA, or RNA
+                        (default: )
+
+System Configuration:
+  -d RUN, --device RUN  Device configuration (default: local)
+  -p DEV, --platform DEV
+                        Processing platform (default: CPU)
+
+Directory Settings:
+  -w DIR, --workdir DIR
+                        Output directory to store runs (default: ./localruns)
+  -md DIR, --mmb_dir DIR
+                        MMB library directory (default: Installer-*/lib)
+  -mb MMB, --mmb MMB    Path to MMB executable (default: Installer-*/bin/MMB)
 ```
-## 2. Running a job
-### Quickstart
-* Set 3 paths in `params`, as indicated in step6 of [Installation](https://github.com/siminegroup/E2EDNA2#1-installation) section. Leave the other keys of `params` unchanged.
-* Run the bash script [automate_tests.sh](https://github.com/siminegroup/E2EDNA2/blob/main/automate_tests.sh) to test run all 8 modes automatically. Check out [Test runs](https://github.com/siminegroup/E2EDNA2#4-test-runs-inputs-and-outcomes) section for details. 
-* All 8 modes take about 15 minutes to run on a macbook pro laptop and the outputs are saved in the work directory. We chose very simple systems for the the test-run and where ever docking is performed the docking configuration may or may not be found due to the limitations of the chosen system. Please note that a failure to find a docked configuration is not a failure of E2EDNA. 
-* Alternatively, a single run can be carried out by run_num, mode, aptamer sequence, and ligand's structural file. For example,
+
+## 3. Running a job
+### Using the test script
+* Run the bash script [automate_tests.sh](https://github.com/siminegroup/E2EDNA2/blob/main/automate_tests.sh) to test run all 8 modes automatically. Check out [Test runs](https://github.com/siminegroup/E2EDNA2#5-test-runs-inputs-and-outcomes) section for details. 
+* All 8 modes take about 15 minutes to run on a macbook pro laptop and the outputs are saved in the work directory. We chose very simple systems for the the test-run and where ever docking is performed the docking configuration may or may not be found due to the limitations of the chosen system. Please note that a failure to find a docked configuration is not a failure of E2EDNA.
+
+Running on your own data
+* Alternatively, a single run can be carried out by specifying the following parameters: run_num, mode, aptamer sequence, and ligand's structural file. For example,
 ```
-python main.py --run_num=1 --mode='free aptamer' --aptamerSeq='TAATGTTAATTG' --ligand='False' --ligandType='' --ligandSeq=''
-python main.py --run_num=2 --mode='full dock' --aptamerSeq='TAATGTTAATTG' --ligand='YQTQ.pdb' --ligandType='peptide' --ligandSeq='YQTQTNSPRRAR'
-    
-# --ligand='False'        # if no ligand. --ligandType and --ligandSeq will be ignored.
-# --ligandType='peptide'  # or 'DNA' or 'RNA' or 'other'. Assuming 'other' ligand can be described by Amber14 force field.
-# --ligandSeq=''          # if no sequence. For instance, when ligandType is 'other'
+# Modeling a free aptamer with no ligand
+./main.py --run_num 1 --mode 'free aptamer' --aptamer TAATGTTAATTG --ligand False
+
+# Model full docking of ligand + aptamer
+./main.py --run_num 2 --mode 'full dock' --aptamer TAATGTTAATTG --ligand YQTQ.pdb --ligand_type peptide --ligand_seq YQTQTNSPRRAR
 ```
 ### Customizing parameters
-* parameters passed as command line inputs:
-  * `--run_num`: is used to name the folder for each job.
-  * `--aptamerSeq`: DNA aptamer sequence (5'->3').
-  * `--ligand`: PDB filename of target ligand; If no ligand, `--ligand='False'` and the following two inputs can be empty strings.
-  * `--ligandType`: 'peptide' or 'DNA' or 'RNA' or 'other', assuming 'other' ligand can be described by force field used in MD simulation (default: Amber14).
-  * `--ligandSeq`: target ligand's sequence (5'->3') if target ligand is a peptide or DNA or RNA. If `--ligandType='other'`, this input is empty string.
-* A handful of parameters can be adjusted in [main.py](https://github.com/siminegroup/E2EDNA2/blob/main/main.py) to allow for flexible control of the simulation conditions, including device platform (CPU or CUDA), solvent ionic strength, temperature, pH, implicit solvent, simulation force field, etc.
 
-## 3. Functionality: Eight different modes of operation
+Parameters passed as command line inputs:
+* Run parameters
+  * `-r/--run_num`: is used to name the folder for each job.
+  * `-m/--mode`: mode of operation; one of the modes described in [Functionality](https://github.com/siminegroup/E2EDNA2#4-functionality_eight_different_modes_of_operation) -- '2d structure', '3d coarse', '3d smooth', 'coarse dock', 'smooth dock', 'free aptamer', 'full dock', 'full binding'
+  * `-a/--aptamer`: DNA aptamer sequence (5'->3'). Can be a string or the name of a readable text file containing the sequence.
+  * `-l/--ligand`: PDB filename of target ligand; If no ligand, `--ligand False` and the following two inputs (`--ligand_type` and `--ligand_seq`) can be left off.
+  * `-t/--ligand_type`: 'peptide', 'DNA', 'RNA', or 'other', assuming 'other' ligand can be described by force field used in MD simulation (default: Amber14).
+  * `-s/--ligand_seq`: target ligand's sequence (5'->3') if target ligand is a peptide or DNA or RNA. Can be a string or the name of a readable text file containing the sequence. If `--ligand_type='other'`, do not use this flag.
+* System Configuration
+  * `-d/--device`: running device; either 'local' or 'cluster'
+  * `-p/--platform`: processing platform; either 'CPU' or 'CUDA'
+* Directory Settings
+  * `-w/--workdir`: ouput directory to write results for each run
+  * `-md/--mmb_dir`: MMB library directory. Wildcards can be used to describe location, for instance the default is "Installer-*/lib" which will match both "Installer-3.0-Ubuntu18.04/lib" and "Installer.3_0.OSX/lib". Both absolute and relative paths are accepted.
+  * `-mb/--mmb`: path to MMB executable. Wild cards can be used to describe location.
+
+* A handful of parameters can be adjusted in [main.py](https://github.com/siminegroup/E2EDNA2/blob/main/main.py) to allow for flexible control of the simulation conditions, including solvent ionic strength, temperature, pH, implicit solvent, simulation force field, etc.
+
+## 4. Functionality: Eight different modes of operation
 E2EDNA 2.0 takes in a DNA aptamer sequence (5' to 3'), and optionally a short peptide or other small molecule, and returns details of the aptamer structure and binding behaviour.
 This code implements several distinct operation modes so users may customize the level of computational cost and accuracy.
 
@@ -60,11 +108,11 @@ This code implements several distinct operation modes so users may customize the
 * `full dock` &rarr; Return best docking configurations and scores from a LightDock run using the fully-equilibrated aptamer structure 'free aptamer'. Similar cost (LightDock is relatively cheap)
 * `full binding` &rarr; Same steps as 'full dock', with follow-up extended MD simulation of the best binding configuration. Slowest, O(hours).
 
-## 4. Test runs: inputs and outcomes
+## 5. Test runs: inputs and outcomes
 Running this script [automate_tests.sh](https://github.com/siminegroup/E2EDNA2/blob/main/automate_tests.sh) will automatically run light tests of all 8 modes.
 Here we explain what outputs to look for and what success looks like for each mode.
 
-1. `--mode='2d structure'`
+1. `--mode '2d structure'`
 
 * **Key inputs**: DNA aptamer sequence
 
@@ -72,7 +120,7 @@ Here we explain what outputs to look for and what success looks like for each mo
 
 * **Success evaluation**: observe the dot-bracket notion for secondary structure, such as .(((....))).
 
-2. `--mode='3d coarse'`
+2. `--mode '3d coarse'`
 
 * **Key inputs**: DNA aptamer sequence
 
@@ -81,7 +129,7 @@ Here we explain what outputs to look for and what success looks like for each mo
 * **Success evaluation**: visualize MMB-folded aptamer structure in software like VMD or PyMOL 
 
 
-3. `--mode='3d smooth'`
+3. `--mode '3d smooth'`
 
 * **Key inputs**: DNA aptamer sequence
 
@@ -89,7 +137,7 @@ Here we explain what outputs to look for and what success looks like for each mo
 
 * **Success evaluation**: simulation logfile, MDlog_freeAptamerSmoothing.txt, indicates 100% completion; visualize the relaxation trajectory and relaxed structure in software like VMD or PyMOL 
 
-4. `--mode='coarse dock'`
+4. `--mode 'coarse dock'`
 
 * **Key inputs**: DNA aptamer sequence; PDB filename of target ligand
 
@@ -97,7 +145,7 @@ Here we explain what outputs to look for and what success looks like for each mo
 
 * **Success evaluation**: visualize the docked structure, if docking happened, in software like VMD or PyMOL 
 
-5. `--mode='smooth dock'`
+5. `--mode 'smooth dock'`
 
 * **Key inputs**: DNA aptamer sequence; PDB filename of target ligand
 
@@ -106,7 +154,7 @@ Here we explain what outputs to look for and what success looks like for each mo
 * **Success evaluation**: visualize the docked structure, if docking happened, in software like VMD or PyMOL 
 
 
-6. `--mode='free aptamer'`
+6. `--mode 'free aptamer'`
 
 * **Key inputs**: DNA aptamer sequence
 
@@ -114,13 +162,13 @@ Here we explain what outputs to look for and what success looks like for each mo
 
 * **Success evaluation**: simulation logfile, MDlog_freeAptamerSampling.txt, indicates 100% completion; visualize the sampling trajectory and representative structure of free aptamer in software like VMD or PyMOL 
 
-7. `--mode='full dock'`
+7. `--mode 'full dock'`
 
 * **Key inputs**: DNA aptamer sequence; PDB filename of target ligand
 * **Outputs**: predicted secondary structure in record.txt; MMB-folded aptamer structure: foldedAptamer_0.pdb; Long MD sampling trajectory of free aptamer: foldedAptamer_0_processed_complete_trajectory.dcd and clean_foldedAptamer_0_processed_complete_trajectory.dcd (without solvent and ions); Representative structure of free aptamer: repStructure_0.pdb; Representative aptamer docked by target ligand: complex_0_0.pdb (if docking happened)
 * **Success evaluation**: visualize the docked structure, if docking happened, in software like VMD or PyMOL 
 
-8. `--mode='full binding'`
+8. `--mode 'full binding'`
 
 * **Key inputs**: DNA aptamer sequence; PDB filename of target ligand
 

--- a/automate_tests.sh
+++ b/automate_tests.sh
@@ -7,20 +7,20 @@ printf "Start automating tests one by one...\n"
 printf "===================================="
 
 printf "\nTESTING MODE #1: '2d structure'\n"
-python main.py --outdir 1 --mode '2d structure' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run1.out
+python main.py  --run_num 1 --mode '2d structure' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run1.out
 printf "\nEND OF TEST #1. Results are saved to folder \"run1\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "===================================="
 
 printf "\nTESTING MODE #2: '3d coarse'\n"
-python main.py --outdir 2 --mode '3d coarse' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run2.out
+python main.py  --run_num 2 --mode '3d coarse' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run2.out
 printf "\nEND OF TEST #2. Results are saved to folder \"run2\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
 printf "===================================="
 
 printf "\nTESTING MODE #3: '3d smooth'\n"
-python main.py --outdir 3 --mode '3d smooth' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run3.out
+python main.py  --run_num 3 --mode '3d smooth' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run3.out
 printf "\nEND OF TEST #3. Results are saved to folder \"run3\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -29,7 +29,7 @@ printf "\tRelaxed aptamer structure: relaxedAptamer_0.pdb\n"
 printf "===================================="
 
 printf "\nTESTING MODE #4: 'coarse dock'\n"
-python main.py --outdir 4 --mode 'coarse dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run4.out
+python main.py  --run_num 4 --mode 'coarse dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run4.out
 printf "\nEND OF TEST #4. Results are saved to folder \"run4\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -37,7 +37,7 @@ printf "\tMMB-folded aptamer docked by target ligand: complex_0_0.pdb (if dockin
 printf "===================================="
 
 printf "\nTESTING MODE #5: 'smooth dock'\n"
-python main.py --outdir 5 --mode 'smooth dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run5.out
+python main.py  --run_num 5 --mode 'smooth dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run5.out
 printf "\nEND OF TEST #5. Results are saved to folder \"run5\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -47,7 +47,7 @@ printf "\tRelaxed aptamer docked by target ligand: complex_0_0.pdb (if docking h
 printf "===================================="
 
 printf "\nTESTING MODE #6: 'free aptamer'\n"
-python main.py --outdir 6 --mode 'free aptamer' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run6.out
+python main.py  --run_num 6 --mode 'free aptamer' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run6.out
 printf "\nEND OF TEST #6. Results are saved to folder \"run6\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -56,7 +56,7 @@ printf "\tRepresentative structure of free aptamer: repStructure_0.pdb\n"
 printf "===================================="
 
 printf "\nTESTING MODE #7: 'full dock'\n"
-python main.py --outdir 7 --mode 'full dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run7.out
+python main.py  --run_num 7 --mode 'full dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run7.out
 printf "\nEND OF TEST #7. Results are saved to folder \"run7\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -66,7 +66,7 @@ printf "\tRepresentative aptamer docked by target ligand: complex_0_0.pdb (if do
 printf "===================================="
 
 printf "\nTESTING MODE #8: 'full binding'\n"
-python main.py --outdir 8 --mode 'full binding' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run8.out
+python main.py  --run_num 8 --mode 'full binding' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run8.out
 printf "\nEND OF TEST #8. Results are saved to folder \"run8\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"

--- a/automate_tests.sh
+++ b/automate_tests.sh
@@ -7,20 +7,20 @@ printf "Start automating tests one by one...\n"
 printf "===================================="
 
 printf "\nTESTING MODE #1: '2d structure'\n"
-python main.py --run_num=1 --mode='2d structure' --aptamerSeq='TAATGTTAATTG' --ligand='False' --ligandType='' --ligandSeq='' #> run1.out
+python main.py --outdir 1 --mode '2d structure' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run1.out
 printf "\nEND OF TEST #1. Results are saved to folder \"run1\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "===================================="
 
 printf "\nTESTING MODE #2: '3d coarse'\n"
-python main.py --run_num=2 --mode='3d coarse' --aptamerSeq='TAATGTTAATTG' --ligand='False' --ligandType='' --ligandSeq='' #> run2.out
+python main.py --outdir 2 --mode '3d coarse' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run2.out
 printf "\nEND OF TEST #2. Results are saved to folder \"run2\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
 printf "===================================="
 
 printf "\nTESTING MODE #3: '3d smooth'\n"
-python main.py --run_num=3 --mode='3d smooth' --aptamerSeq='TAATGTTAATTG' --ligand='False' --ligandType='' --ligandSeq='' #> run3.out
+python main.py --outdir 3 --mode '3d smooth' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run3.out
 printf "\nEND OF TEST #3. Results are saved to folder \"run3\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -29,7 +29,7 @@ printf "\tRelaxed aptamer structure: relaxedAptamer_0.pdb\n"
 printf "===================================="
 
 printf "\nTESTING MODE #4: 'coarse dock'\n"
-python main.py --run_num=4 --mode='coarse dock' --aptamerSeq='TAATGTTAATTG' --ligand='YQTQ.pdb' --ligandType='peptide' --ligandSeq='YQTQTNSPRRAR' #> run4.out
+python main.py --outdir 4 --mode 'coarse dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run4.out
 printf "\nEND OF TEST #4. Results are saved to folder \"run4\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -37,7 +37,7 @@ printf "\tMMB-folded aptamer docked by target ligand: complex_0_0.pdb (if dockin
 printf "===================================="
 
 printf "\nTESTING MODE #5: 'smooth dock'\n"
-python main.py --run_num=5 --mode='smooth dock' --aptamerSeq='TAATGTTAATTG' --ligand='YQTQ.pdb' --ligandType='peptide' --ligandSeq='YQTQTNSPRRAR' #> run5.out
+python main.py --outdir 5 --mode 'smooth dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run5.out
 printf "\nEND OF TEST #5. Results are saved to folder \"run5\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -47,7 +47,7 @@ printf "\tRelaxed aptamer docked by target ligand: complex_0_0.pdb (if docking h
 printf "===================================="
 
 printf "\nTESTING MODE #6: 'free aptamer'\n"
-python main.py --run_num=6 --mode='free aptamer' --aptamerSeq='TAATGTTAATTG' --ligand='False' --ligandType='' --ligandSeq='' #> run6.out
+python main.py --outdir 6 --mode 'free aptamer' --aptamer 'TAATGTTAATTG' --ligand 'False' --ligand_type '' --ligand_seq '' #> run6.out
 printf "\nEND OF TEST #6. Results are saved to folder \"run6\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -56,7 +56,7 @@ printf "\tRepresentative structure of free aptamer: repStructure_0.pdb\n"
 printf "===================================="
 
 printf "\nTESTING MODE #7: 'full dock'\n"
-python main.py --run_num=7 --mode='full dock' --aptamerSeq='TAATGTTAATTG' --ligand='YQTQ.pdb' --ligandType='peptide' --ligandSeq='YQTQTNSPRRAR' #> run7.out
+python main.py --outdir 7 --mode 'full dock' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run7.out
 printf "\nEND OF TEST #7. Results are saved to folder \"run7\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"
@@ -66,7 +66,7 @@ printf "\tRepresentative aptamer docked by target ligand: complex_0_0.pdb (if do
 printf "===================================="
 
 printf "\nTESTING MODE #8: 'full binding'\n"
-python main.py --run_num=8 --mode='full binding' --aptamerSeq='TAATGTTAATTG' --ligand='YQTQ.pdb' --ligandType='peptide' --ligandSeq='YQTQTNSPRRAR' #> run8.out
+python main.py --outdir 8 --mode 'full binding' --aptamer 'TAATGTTAATTG' --ligand 'YQTQ.pdb' --ligand_type 'peptide' --ligand_seq 'YQTQTNSPRRAR' #> run8.out
 printf "\nEND OF TEST #8. Results are saved to folder \"run8\", where:\n"
 printf "\t2d structure: in record.txt\n"
 printf "\tMMB-folded aptamer structure: foldedAptamer_0.pdb\n"

--- a/main.py
+++ b/main.py
@@ -206,7 +206,6 @@ else:  # params['device'] == 'cluster':
     params['mmb dir'] = '~/projects/def-simine/programs/MMB/Installer.2_14.Linux64'
     params['mmb'] = '~/projects/def-simine/programs/MMB/Installer.2_14.Linux64/MMB.2_14.Linux64'
 params['explicit run enumeration'] = True  # To resume a previous run from .chk file, use ``False`` here
-# cmdLineInputs = get_input()  # get input arguments from command lines
 params['run num'] = args.run_num
 params['mode'] = args.mode
 params['aptamerSeq'] = args.aptamer

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ import argparse
 import glob
 from opendna import *
 import os
+import shutil
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -132,10 +133,10 @@ def get_args():
 
     # Check if output directory for run exists;
     # Either fail or force overwrite if so
-    out_dir = os.path.join(args.workdir, str(args.outdir))
+    out_dir = os.path.join(args.workdir, 'run' + str(args.outdir))
     if os.path.isdir(out_dir):
         if args.force:
-            os.removedirs()
+            shutil.rmtree(out_dir)
         else:
             parser.error(f'--outdir already exists at {out_dir}\n'
                         '\t use -f/--force to overwrite')
@@ -176,13 +177,21 @@ def get_args():
     if not glob.glob(args.mmb_dir):
         parser.error(f'MMB library could not be found at {args.mmb_dir}.')
     else:
-        args.mmb_dir = glob.glob(args.mmb_dir)[0]
+        found_path = glob.glob(args.mmb_dir)[0]
+        if os.getcwd() in found_path: # Already absolute path
+            args.mmb_dir = found_path
+        else: # Need to make absolute path
+            args.mmb_dir = os.path.join(os.getcwd(), found_path)
 
     # Try to find MMB executable
     if not glob.glob(args.mmb):
         parser.error(f'MMB executable could not be found at {args.mmb}.')
     else:
-        args.mmb = glob.glob(args.mmb)[0]
+        found_path = glob.glob(args.mmb)[0]
+        if os.getcwd() in found_path: # Already absolute path
+            args.mmb = found_path
+        else: # Need to make absolute path
+            args.mmb = os.path.join(os.getcwd(), found_path)
 
     return args
 

--- a/main.py
+++ b/main.py
@@ -42,12 +42,17 @@ def get_args():
     system_info = parser.add_argument_group('System Configuration')
     paths = parser.add_argument_group('Directory Settings')
 
-    run_info.add_argument('-o',
-                             '--outdir',
-                             metavar='DIR',
+    parser.add_argument('-f',
+                             '--force',
+                             action='store_true',
+                             help='Overwrite existing --run_num')
+
+    run_info.add_argument('-r',
+                             '--run_num',
+                             metavar='INT',
                              type=int,
                              required=True,
-                             help='Output directory for run created in --workdir')
+                             help='Run number. Output will be written to {--workdir}/run{--run_num}/')
     run_info.add_argument('-m',
                              '--mode',
                              metavar='MODE',
@@ -79,10 +84,6 @@ def get_args():
                              type=str,
                              default='',
                              help='Target ligand sequence if peptide, DNA, or RNA')
-    run_info.add_argument('-f',
-                             '--force',
-                             action='store_true',
-                             help='Overwrite existing --outdir')
     
 
     system_info.add_argument('-d',
@@ -127,12 +128,12 @@ def get_args():
 
     # Check if output directory for run exists;
     # Either fail or force overwrite if so
-    out_dir = os.path.join(args.workdir, 'run' + str(args.outdir))
+    out_dir = os.path.join(args.workdir, 'run' + str(args.run_num))
     if os.path.isdir(out_dir):
         if args.force:
             shutil.rmtree(out_dir)
         else:
-            parser.error(f'--outdir already exists at {out_dir}\n'
+            parser.error(f'--run_num already exists at {out_dir}\n'
                         '\t use -f/--force to overwrite')
 
     # Validate run mode
@@ -206,7 +207,7 @@ else:  # params['device'] == 'cluster':
     params['mmb'] = '~/projects/def-simine/programs/MMB/Installer.2_14.Linux64/MMB.2_14.Linux64'
 params['explicit run enumeration'] = True  # To resume a previous run from .chk file, use ``False`` here
 # cmdLineInputs = get_input()  # get input arguments from command lines
-params['run num'] = args.outdir
+params['run num'] = args.run_num
 params['mode'] = args.mode
 params['aptamerSeq'] = args.aptamer
 params['target ligand'] = args.ligand

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ import argparse
 import glob
 from opendna import *
 import os
+import platform
 import shutil
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -91,13 +92,6 @@ def get_args():
                              default='local',
                              help='Device configuration',
                              choices=['local', 'cluster'])
-    system_info.add_argument('-os',
-                             '--system',
-                             metavar='OS',
-                             type=str,
-                             default='macos',
-                             help='Operating system',
-                             choices=['macos', 'linux', 'WSL'])
     system_info.add_argument('-p',
                              '--platform',
                              metavar='DEV',
@@ -199,7 +193,7 @@ args=get_args()
 params = {}
 # ============================================= Specify your settings within this block for a local test ===================================================
 params['device'] = args.device
-params['device platform'] = args.system
+params['device platform'] = platform.system().lower()
 params['platform'] = args.platform
 if params['platform'] == 'CUDA': params['platform precision'] = 'single'  # 'single' or 'double'
 if params['device'] == 'local':

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 '''
 E2EDNA 2.0 - OpenMM Implementation of E2EDNA !
 

--- a/main.py
+++ b/main.py
@@ -58,7 +58,10 @@ def get_args():
                              metavar='MODE',
                              type=str,
                              required=True,
-                             help='Run mode')
+                             help='Run mode',
+                             choices=['2d structure', '3d coarse', '3d smooth',
+                                      'coarse dock', 'smooth dock', 'free aptamer',
+                                      'full dock', 'full binding'])
     run_info.add_argument('-a',
                              '--aptamer',
                              metavar='SEQ',
@@ -135,15 +138,6 @@ def get_args():
         else:
             parser.error(f'--run_num already exists at {out_dir}\n'
                         '\t use -f/--force to overwrite')
-
-    # Validate run mode
-    valid_modes = ['2d structure', '3d coarse', '3d smooth',
-                   'coarse dock', 'smooth dock', 'free aptamer',
-                   'full dock', 'full binding']
-
-    if args.mode not in valid_modes:
-        parser.error(f'Invalid --mode "{args.mode}". Must be one of: ' +
-                     ', '.join(valid_modes) + '.')
 
     # Read in aptamer sequence if it is in a file
     if os.path.isfile(args.aptamer):

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def get_args():
     run_info.add_argument('-o',
                              '--outdir',
                              metavar='DIR',
-                             type=str,
+                             type=int,
                              required=True,
                              help='Output directory for run created in --workdir')
     run_info.add_argument('-m',
@@ -70,7 +70,7 @@ def get_args():
                              type=str,
                              default='',
                              help='Target ligand molecule type',
-                             choices=['peptide', 'DNA', 'RNA', 'other', 'False'])
+                             choices=['peptide', 'DNA', 'RNA', 'other', ''])
     run_info.add_argument('-s',
                              '--ligand_seq',
                              metavar='SEQ',
@@ -132,7 +132,7 @@ def get_args():
 
     # Check if output directory for run exists;
     # Either fail or force overwrite if so
-    out_dir = os.path.join(args.workdir, args.outdir)
+    out_dir = os.path.join(args.workdir, str(args.outdir))
     if os.path.isdir(out_dir):
         if args.force:
             os.removedirs()
@@ -202,7 +202,7 @@ else:  # params['device'] == 'cluster':
     params['mmb dir'] = '~/projects/def-simine/programs/MMB/Installer.2_14.Linux64'
     params['mmb'] = '~/projects/def-simine/programs/MMB/Installer.2_14.Linux64/MMB.2_14.Linux64'
 params['explicit run enumeration'] = True  # To resume a previous run from .chk file, use ``False`` here
-cmdLineInputs = get_input()  # get input arguments from command lines
+# cmdLineInputs = get_input()  # get input arguments from command lines
 params['run num'] = args.outdir
 params['mode'] = args.mode
 params['aptamerSeq'] = args.aptamer

--- a/main.py
+++ b/main.py
@@ -111,13 +111,13 @@ def get_args():
                           '--mmb_dir',
                           metavar='DIR',
                           type=str,
-                          default='Installer-*/lib',
+                          default='Installer*/lib',
                           help='MMB library directory')
     paths.add_argument('-mb',
                           '--mmb',
                           metavar='MMB',
                           type=str,
-                          default='Installer-*/bin/MMB',
+                          default='Installer*/bin/MMB',
                           help='Path to MMB executable')
 
     args = parser.parse_args()


### PR DESCRIPTION
# Overview
This pull request implements argparse so that the  user is less likely to need to edit source code in main.py. However, more work will need to be done to include parameters related to environmental condotions like ph, etc.

Other than implementing argparse, functionality is the same. Some things are still a bit awkward because I didn't want to change too much beyond that.

# Affected files
The following files have changes:
* main.py: add shebang line, add argument parsing and validation
* automate_tests.sh: update arguments to align with argparse
* README.md: describe current functionality and arguments

# Notes

## main.py
There were a few things that may need to be changed to work most efficiently and predictably.

The relationship between `--ligand`, `--ligand_type`, and `--ligand_seq` is a bit complex and can probably be improved. Ideally, I think `--ligand` would be optional, yielding a default of None. This makes more sense than having to use `--ligand False`. Then `--ligand_type`, and `--ligand_seq` could also be optional with a default of None (instead of an empty string). Only when `--ligand` is present, you validate the others are there and if not `parser.error()`. I also think the authors should consider if `--ligand_seq` is truly required if `--l;igand` is either 'peptide', 'DNA' or 'RNA'. Currently this is enforced (by `parser.error()`), but if it is actually optional, that should be updated.

I left the code that uses different params based on whether it is run as `local` or `cluster`, but I am not sure if it is necessary. I especially think that the hard-coded paths used when it is `cluster` should be removed, and turned into arguments. In which case, it is the same as the usual arguments, and may make `--device` obsolete if there is no difference between local and cluster.

I implemented wildcards to help the user find their MMB paths (lib and executable) within the `--mmb_dir` and `--mmb`. I am hoping the defaults will make it so users don't have to change this argument.

I removed the operating system argument and instead used `platform` to detect it. This new implementation has only been tested on my WSL system, so please check this works. One issue is if the result of `platform.system().lower()` doesn't match an expected value on mac. Initially mine returned `Linux`, which is why I ran `lower()` to make it 'linux' which is compatible with the previous implementation.

Lots of argument validation now happens in `get_args()`, so hopefully more helpful error messages are produced.

I added a feature so that both `--aptamer` and `--ligand_seq` can be names of files. In that case, the file contents are read in and used as the sequences. Literal strings can still be used instead of file names.

## Readme.md

I hope my additions are helpful in describing the current functionality.

One thing I was uncertain is the description of ligand type saying "(default: Amber14)" I didn't see this anywhere that params were set. It is not the default to any arguments I set up. If this needs to be a default, please take note of this.

# Conclusions

Currently, all modes in `automate_tests.sh` run for me, so it seems that these changes are compatible. It would be great to have unit and integration tests with pytest to confirm.

Please check that it works on MacOS still, as I have only tested on WSL.

No additional dependencies have been added, only core libraries were used.

Please feel free to make any changes you see fit or discuss!
